### PR TITLE
fix(ui): prevent popup size from inheriting parent page html font-size

### DIFF
--- a/entrypoints/content/ai_trans_card.vue
+++ b/entrypoints/content/ai_trans_card.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="min-w-[450px] min-h-[165px] rounded-lg shadow-xl w-fit">
+    <div class="w-110 min-h-40 rounded-lg shadow-xl">
         <div class="flex bg-white text-black text-base p-2 items-center justify-between">
             <div class="flex items-center">
                 <div class="px-2">
@@ -16,7 +16,7 @@
                 </svg>
             </div>
         </div>
-        <div class="p-3 bg-gray-200 text-black text-lg font-medium min-h-[150px] max-h-[500px] overflow-y-auto"
+        <div class="p-3 bg-gray-200 text-black text-lg font-medium w-full min-h-40 max-h-100 overflow-y-auto opacity: 1"
             v-html="content.replace(/\n/g, '<br>')">
         </div>
     </div>

--- a/entrypoints/content/word_card.vue
+++ b/entrypoints/content/word_card.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bg-white border-1 border-gray-300 rounded-xl min-w-[420px] min-h-[60px] p-3 text-black">
+    <div class="bg-white border-1 border-gray-300 rounded-xl min-w-100 min-h-15 p-3 text-black">
         <div v-if="loading_flag" class="items-center justify-center flex h-full py-2">
             <div class="loading loading-dots lodding-sm"></div>
         </div>

--- a/libs/highlight_renderer.ts
+++ b/libs/highlight_renderer.ts
@@ -161,7 +161,7 @@ export class HighlightRenderer {
               });
             } else {
               // 没有缓存数据，使用原来的方式
-              select_word_storage.setValue(word);
+              select_word_storage.setValue({ word, context: '' });
               // 创建一个虚拟的选择来获取位置
               const range = document.createRange();
               range.selectNodeContents(target);
@@ -175,7 +175,7 @@ export class HighlightRenderer {
           } catch (error) {
             console.error('Error handling highlight click:', error);
             // 出错时回退到原来的方式
-            select_word_storage.setValue(word);
+            select_word_storage.setValue({ word: word || '', context: '' });
             eventManager.emit('show-word-card');
           }
         }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "vue": "^3.5.21"
   },
   "devDependencies": {
+    "@thedutchcoder/postcss-rem-to-px": "^0.0.2",
     "@wxt-dev/module-vue": "^1.0.2",
+    "postcss": "^8.5.6",
     "typescript": "^5.9.2",
     "vue-tsc": "^3.0.6",
     "wxt": "^0.20.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,15 @@ importers:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
     devDependencies:
+      '@thedutchcoder/postcss-rem-to-px':
+        specifier: ^0.0.2
+        version: 0.0.2(postcss@8.5.6)
       '@wxt-dev/module-vue':
         specifier: ^1.0.2
         version: 1.0.3(vite@7.1.5(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1))(vue@3.5.21(typescript@5.9.2))(wxt@0.20.11(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1))
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -510,6 +516,12 @@ packages:
     resolution: {integrity: sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@thedutchcoder/postcss-rem-to-px@0.0.2':
+    resolution: {integrity: sha512-M2T3bJSTgLtZF8+KDYDtSDAFGuTlaxYfitpjkmNswnfJ8AjbQ/g7NC+bqgAAViYWFV9I3tdrQuQ3Bu8j7GrjwA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      postcss: ^8.3.0
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2444,6 +2456,10 @@ snapshots:
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
       vite: 7.1.5(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)
+
+  '@thedutchcoder/postcss-rem-to-px@0.0.2(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
 
   '@types/estree@1.0.8': {}
 

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,15 @@
+// PostCSS 配置：将所有 CSS 中的 rem 转换为 px
+// 说明：项目使用 @tailwindcss/vite 处理 Tailwind，本文件仅额外添加 rem->px 转换。
+// 插件会在 Tailwind 产物之后运行，从而把 Tailwind 生成的 rem 一并转为 px，避免受宿主页面 <body> font-size 影响。
+
+/** @type {import('postcss').ProcessOptions & { plugins: import('postcss').AcceptedPlugin[] }} */
+module.exports = {
+  plugins: [
+    // 可选项：设置 baseValue 与设计稿一致（默认 16）。
+    // 例：若希望 1rem == 10px，则设置 { baseValue: 10 }
+    require('@thedutchcoder/postcss-rem-to-px')({
+      // 按需修改：默认 16
+      baseValue: 16,
+    }),
+  ],
+};


### PR DESCRIPTION
Because Tailwind CSS uses rem by default, and rem is computed based on the font-size of the html element on the page.

To ensure consistent sizing, introduce @thedutchcoder/postcss-rem-to-px to convert rem to fixed px values.